### PR TITLE
fix(AT-31): fixed images not appearing in catalog for all users

### DIFF
--- a/enhanced/gallery.py
+++ b/enhanced/gallery.py
@@ -122,7 +122,7 @@ def refresh_images_catalog(choice: str, passthrough = False, user = None):
     output_path = config.path_outputs
     if(auth_enabled):
         output_path = output_path.replace("[user]", user)
-    if not passthrough and choice in images_list_keys:
+    if not passthrough and choice in images_list_keys and not auth_enabled:
         images_list_keys.remove(choice)
         images_list_keys.append(choice)
         #print(f'[Gallery] Refresh_images_list: hit cache {len(images_list[choice])} image_items of {choice}.')

--- a/modules/config.py
+++ b/modules/config.py
@@ -157,7 +157,7 @@ def get_path_output() -> str:
         path_output = config_dict['path_outputs']
         path_output_abs = os.path.abspath(path_output)
         config_dict['path_outputs'] = path_output_abs
-    path_output = get_dir_or_set_default('path_outputs', f'../{path_output}')
+    path_output = get_dir_or_set_default('path_outputs', path_output)
     print(f'Generated images will be stored in {path_output}')
     print()
     print('Loading support files...')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved image catalog refresh behavior to prevent cache reordering when authentication is enabled.
	- Adjusted default output directory resolution for more consistent path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->