### PR TITLE
[FIX] add more time before timeout when lora are used (5s -> 5min)

### DIFF
--- a/simpleai_base/comfyclient_pipeline.py
+++ b/simpleai_base/comfyclient_pipeline.py
@@ -25,7 +25,7 @@ def queue_prompt(prompt):
     p = {"prompt": prompt, "client_id": client_id}
     data = json.dumps(p).encode('utf-8')
     try:
-        with httpx.Client() as client:
+        with httpx.Client(timeout=httpx.Timeout(300.0)) as client:
             response = client.post("http://{}/prompt".format(server_address), data=data)
             return json.loads(response.read())
     except httpx.RequestError as e:


### PR DESCRIPTION
Edit the timeout of lora loading, to be able to load an image with a lora in flux, before reach the timeout of 5 seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added request timeout protection to prevent indefinite hangs during network operations. Requests will now timeout after 5 minutes of inactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->